### PR TITLE
More permissive restart config

### DIFF
--- a/livereduce.service
+++ b/livereduce.service
@@ -6,6 +6,9 @@ WorkingDirectory=/tmp
 User=snsdata
 ExecStart=/usr/bin/python /usr/bin/livereduce.py
 Restart=always
+StartLimitInterval=86400
+StartLimitBurst=1000
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The live data listener is clearly having issues with low count rates at the boundary of a run change.
It looks like the listener is not always producing a workspace compatible with the rest of the live listener infrastructure.

Given the nature of the listener and the problem it tries to address, the restart configuration of the service should be more permissive. I propose the changes in this PR as a way to ensure that the service doesn't stop when a failure happens (whatever it is).

This will ensure that the service will attempt to restart at least 1000 times within a day. We also don't need the service to restart immediately. Giving it a delay of 10-ish seconds is probably more appropriate.