### PR TITLE
Merge mantid and python logging

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,9 @@ name: livereduce
 
 channels:
   - conda-forge
+  - mantid
 
 dependencies:
+  - mantid # framework only
+  - pyinotify
   - pre-commit

--- a/livereduce.spec
+++ b/livereduce.spec
@@ -5,7 +5,7 @@
 
 Summary: %{summary}
 Name: python-%{srcname}
-Version: 1.7
+Version: 1.8
 Release: %{release}%{?dist}
 Source0: %{srcname}-%{version}.tar.gz
 License: MIT

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
 line-length = 120
 # https://beta.ruff.rs/docs/rules/
-select = ["A", "ARG", "BLE", "E", "F", "I", "PT", "UP"]
+select = ["A", "ARG", "BLE", "E", "F", "I", "PT", "S", "UP"]
 ignore = []

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
 line-length = 120
 # https://beta.ruff.rs/docs/rules/
-select = ["A", "ARG", "BLE", "E", "F", "I", "PT", "S", "UP"]
+select = ["A", "ARG", "BLE", "E", "F", "I", "PL", "PT", "S", "UP"]
 ignore = []

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
 line-length = 120
 # https://beta.ruff.rs/docs/rules/
-select = ["A", "ARG", "BLE", "E", "F", "I", "PL", "PT", "S", "UP"]
+select = ["A", "ARG", "BLE", "E", "F", "I", "PL", "PT", "RUF", "S", "UP"]
 ignore = []

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -52,7 +52,7 @@ logger.info(f"using python interpreter {sys.executable}")
 class LiveDataManager:
     """class for handling ``StartLiveData`` and ``MonitorLiveData``"""
 
-    logger = logger or logging.getLogger("LiveDataManager")
+    logger = logging.getLogger(LOG_NAME + ".LiveDataManager")
 
     def __init__(self, config):
         self.config = config
@@ -120,7 +120,7 @@ class Config:
 
     def __init__(self, filename):
         r"""Optional argument is the json formatted config file"""
-        self.logger = logger or logging.getLogger("Config")
+        self.logger = logging.getLogger(LOG_NAME + ".Config")
 
         # read file from json into a dict
         self.filename = None
@@ -268,7 +268,7 @@ class Config:
 
 ####################
 class EventHandler(pyinotify.ProcessEvent):
-    logger = logger or logging.getLogger("EventHandler")
+    logger = logging.getLogger(LOG_NAME + ".EventHandler")
 
     def __init__(self, config, livemanager):
         # files that we actually care about

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -273,7 +273,8 @@ class EventHandler(pyinotify.ProcessEvent):
 
     def _md5(self, filename):
         if filename and os.path.exists(filename):
-            return md5(open(filename, "rb").read()).hexdigest()
+            # this cannot change until python3.9 is the oldest version used
+            return md5(open(filename, "rb").read()).hexdigest()  # noqa: S324
         else:
             return ""
 

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -142,7 +142,7 @@ class Config:
         self.logger.info(f'mantid_loc="{os.path.dirname(mantid.__file__)}"')
 
         try:
-            from mantid.kernel import UsageService  # noqa
+            from mantid.kernel import UsageService
 
             # to differentiate from other apps
             UsageService.setApplicationName("livereduce")

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -10,6 +10,7 @@ import mantid  # for clearer error message
 import pyinotify
 from mantid.simpleapi import StartLiveData
 from mantid.utils.logging import log_to_python as mtd_log_to_python
+from packging.version import parse as parse_version
 
 # ##################
 # configure logging
@@ -287,8 +288,12 @@ class EventHandler(pyinotify.ProcessEvent):
 
     def _md5(self, filename):
         if filename and os.path.exists(filename):
-            # this cannot change until python3.9 is the oldest version used
-            return md5(open(filename, "rb").read()).hexdigest()  # noqa: S324
+            # starting in python 3.9 one can point out md5 is not used in security context
+            if parse_version(sys.version) < parse_version("3.9"):
+                md5sum = md5(open(filename, "rb").read())  # noqa: S324
+            else:
+                md5sum = md5(open(filename, "rb").read(), usedforsecurity=False)
+            return md5sum.hexdigest()
         else:
             return ""
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="livereduce",
-    version="1.7",
+    version="1.8",
     description="Need a description",
     author="Pete Peterson",
     author_email="petersonpf@ornl.gov",

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,7 @@
 This should be a fully working example. All that you need is to add a
 working version of mantid. Please note that the server and client need
-to be started separately.
+to be started separately and are configured to be executed with the
+conda environment activated
 
 Start Live Data Server
 ----------------------

--- a/test/fake.conf
+++ b/test/fake.conf
@@ -2,6 +2,7 @@
   "instrument": "ISIS_Histogram",
   "script_dir": "test",
   "update_every": 3,
+  "CONDA_ENV": "livereduce",
   "accum_method":"Replace",
   "periods":[1,3]
 }


### PR DESCRIPTION
Combine the mantid and livereduce logs together in the file. The console is still only mantid.

*To test:*

Follow the directions in the `test/README.md`, but with a third terminal doing `tail -F livereduce.log`