### PR TITLE
Change how version is compiled into something useful

### DIFF
--- a/livereduce.spec
+++ b/livereduce.spec
@@ -5,7 +5,7 @@
 
 Summary: %{summary}
 Name: python-%{srcname}
-Version: 1.9
+Version: 1.10
 Release: %{release}%{?dist}
 Source0: %{srcname}-%{version}.tar.gz
 License: MIT

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -289,7 +289,7 @@ class EventHandler(pyinotify.ProcessEvent):
     def _md5(self, filename):
         if filename and os.path.exists(filename):
             # starting in python 3.9 one can point out md5 is not used in security context
-            if parse_version(sys.version) < parse_version("3.9"):
+            if parse_version(f"{sys.version_info.major}.{sys.version_info.minor}") < parse_version("3.9"):
                 md5sum = md5(open(filename, "rb").read())  # noqa: S324
             else:
                 md5sum = md5(open(filename, "rb").read(), usedforsecurity=False)


### PR DESCRIPTION
In a conda environment the string returned by `sys.version` has a lot more information at the end of the string. This generates its own simple version number using the object itself.