### PR TITLE
Use newer systemd and update README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -10,16 +10,16 @@ repos:
       - id: check-merge-conflict
       - id: end-of-file-fixer
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.5.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 24.4.2
     hooks:
       - id: black
         args: ['--line-length=120']
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
     - id: codespell

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 Configuration and logging
 -------------------------
 
-The configuration is automatically read from `/etc/livereduce.conf`
-unless specified as a command line argument. Defaults will be
-attempted to be determined from the environment. A minimal configuration to specify using nightly builds of mantid is
+The configuration is automatically read from `/etc/livereduce.conf`unless specified as a command line argument.
+Defaults will be attempted to be determined from the environment.
+A minimal configuration to specify using nightly builds of mantid installed in a conda environment `mantid-dev` is
 ```json
 {
   "instrument": "PG3",
-  "mantid_loc": "/opt/mantidnightly/bin"
+  "CONDA_ENV": "mantid-dev"
 }
 ```
 For testing a configuration file can be supplied as a command line argument when running
@@ -34,6 +34,9 @@ to see the last 25 lines (`-n 25`) mantid wrote to `stdout` with the full
 information for each line (`-l`). People with extra permissions can run
 ``sudo journalctl -u livereduce -f`` and see all of the logs without them
 flushing on restart of the service.
+
+If the instrument is not defined in the configuration file (default is `/etc/livereduce.conf`) the software will ask mantid for the default instrument using `mantid.kerel.ConfigService.getInstrument()` ([docs](https://docs.mantidproject.org/nightly/api/python/mantid/kernel/ConfigServiceImpl.html#mantid.kernel.ConfigServiceImpl.getInstrument)).
+The default instrument is controlled in the [mantid properties files](https://docs.mantidproject.org/nightly/concepts/PropertiesFile.html) and is typically defined in `/etc/mantid.local.properties`.
 
 The script files that are used/looked for are
 

--- a/livereduce.service
+++ b/livereduce.service
@@ -1,14 +1,13 @@
 [Unit]
 Description=Live processing service
+StartLimitInterval=8640
+StartLimitBurst=1000
 
 [Service]
 WorkingDirectory=/tmp
 User=snsdata
 ExecStart=/usr/bin/livereduce.sh
 Restart=always
-# StartLimitInterval and StartLimitBurst were moved to [Unit] in systemd version 241
-StartLimitInterval=8640
-StartLimitBurst=1000
 RestartSec=10
 
 [Install]

--- a/livereduce.spec
+++ b/livereduce.spec
@@ -5,7 +5,7 @@
 
 Summary: %{summary}
 Name: python-%{srcname}
-Version: 1.11
+Version: 1.12
 Release: %{release}%{?dist}
 Source0: %{srcname}-%{version}.tar.gz
 License: MIT
@@ -22,6 +22,7 @@ BuildRequires: systemd-rpm-macros
 Requires: python%{python3_pkgversion}
 Requires: jq
 Requires: nsd-app-wrap
+Requires: systemd
 
 %description
 There should be a meaningful description, but it is not needed quite yet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "livereduce"
 description = "Daemon for running live data reduction with systemd"
-version="1.11"
+version="1.12"
 #dynamic = ["version"]
 requires-python = ">=3.9"
 license = { text = "MIT License" }

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -127,7 +127,7 @@ class Config:
         self.filename = None
         if filename is not None and os.path.exists(filename) and os.path.getsize(filename) > 0:
             self.filename = os.path.abspath(filename)
-            self.logger.info("Loading configuration from '%s'" % filename)
+            self.logger.info(f"Loading configuration from '{filename}'")
             with open(filename) as handle:
                 json_doc = json.load(handle)
             logger.debug(json.dumps(json_doc))
@@ -161,7 +161,7 @@ class Config:
         # location of the scripts
         self.script_dir = json_doc.get("script_dir")
         if self.script_dir is None:
-            self.script_dir = "/SNS/%s/shared/livereduce" % self.instrument.shortName()
+            self.script_dir = f"/SNS/{self.instrument.shortName()!s}/shared/livereduce"
         else:
             self.script_dir = os.path.abspath(self.script_dir)
 
@@ -198,22 +198,22 @@ class Config:
 
         allowed = alg.getProperty("AccumulationMethod").allowedValues
         if self.accumMethod not in allowed:
-            msg = "accumulation method '%s' is not allowed " % self.accumMethod
+            msg = f"accumulation method '{self.accumMethod}' is not allowed "
             msg += str(allowed)
             raise ValueError(msg)
 
     def __determineScriptNames(self):
-        filenameStart = "reduce_%s_live" % str(self.instrument.shortName())
+        filenameStart = f"reduce_{self.instrument.shortName()!s}_live"
 
         # script for processing each chunk
         self.procScript = filenameStart + "_proc.py"
         self.procScript = os.path.join(self.script_dir, self.procScript)
         if not os.path.exists(self.procScript):
-            msg = "ProcessingScriptFilename '%s' does not exist" % self.procScript
+            msg = f"ProcessingScriptFilename '{self.procScript}' does not exist"
             raise RuntimeError(msg)
 
         if os.path.getsize(self.procScript) <= 0:
-            msg = "ProcessingScriptFilename '%s' is empty" % self.procScript
+            msg = f"ProcessingScriptFilename '{self.procScript}' is empty"
             raise RuntimeError(msg)
 
         # script for processing accumulation


### PR DESCRIPTION
While debugging issues with one of the instruments, it was discovered that the README was out of date and there was a TODO in the `.service` file. This fixes the TODO and README.

It also adds links to resources in the mantid docs for more information on how things work.

Testing
-------
The rpm was built and installed on bl100-analysis0 then I ran
```sh
$ sudo service livereduce status
Redirecting to /bin/systemctl status livereduce.service
○ livereduce.service - Live processing service
     Loaded: loaded (/usr/lib/systemd/system/livereduce.service; disabled; pres>
     Active: inactive (dead)
(╯°□°)╯⏜ ┻━┻ ⏜ 3
```
which suggests that the changes to the service file are fine.