### PR TITLE
update the default instrument if necessary

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -10,16 +10,16 @@ repos:
       - id: check-merge-conflict
       - id: end-of-file-fixer
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.2
+    rev: v0.9.4
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 25.1.0
     hooks:
       - id: black
         args: ['--line-length=120']
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
     - id: codespell

--- a/livereduce.spec
+++ b/livereduce.spec
@@ -5,7 +5,7 @@
 
 Summary: %{summary}
 Name: python-%{srcname}
-Version: 1.12
+Version: 1.13
 Release: %{release}%{?dist}
 Source0: %{srcname}-%{version}.tar.gz
 License: MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "livereduce"
 description = "Daemon for running live data reduction with systemd"
-version="1.12"
+version="1.13"
 #dynamic = ["version"]
 requires-python = ">=3.9"
 license = { text = "MIT License" }

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -217,7 +217,11 @@ class Config:
 
             if instrument is None:
                 self.logger.info("Using default instrument")
-                return ConfigService.getInstrument()
+                instrument = ConfigService.getInstrument().strip()
+                if len(instrument) == 0:
+                    raise RuntimeError("No instrument found in the configuration or Mantid.user.properties files")
+                else:
+                    return instrument
             else:
                 self.logger.info("Converting instrument using ConfigService")
                 instrument_instance = ConfigService.getInstrument(str(instrument))

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -217,8 +217,8 @@ class Config:
 
             if instrument is None:
                 self.logger.info("Using default instrument")
-                instrument = ConfigService.getInstrument().strip()
-                if len(instrument) == 0:
+                instrument = ConfigService.getInstrument()
+                if len(instrument.name().strip()) == 0:
                     raise RuntimeError("No instrument found in the configuration or Mantid.user.properties files")
                 else:
                     return instrument

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -13,7 +13,7 @@ import mantid  # for clearer error message
 import psutil
 import pyinotify
 from mantid.kernel import InstrumentInfo
-from mantid.simpleapi import mtd, StartLiveData
+from mantid.simpleapi import StartLiveData, mtd
 from mantid.utils.logging import log_to_python as mtd_log_to_python
 from packaging.version import parse as parse_version
 
@@ -225,11 +225,11 @@ class Config:
                 # set the facility if not the default
                 if facility != ConfigService.getFacility().name():
                     ConfigService.setFacility(facility)
-                    self.logger.info(f"Default Facility set to {str(facility)}")
+                    self.logger.info(f"Default Facility set to {facility!s}")
                 # set the instrument if not the default. Prefer `str(inst)` over `inst.name()`
                 if str(instrument_instance) != str(ConfigService.getInstrument()):
                     ConfigService["default.instrument"] = str(instrument_instance)
-                    self.logger.info(f"Default Instrument set to {str(instrument_instance)}")
+                    self.logger.info(f"Default Instrument set to {instrument_instance!s}")
                 return instrument_instance
         except ImportError:
             self.logger.error("Failed to import mantid.ConfigService", exc_info=True)

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -104,7 +104,7 @@ sig_name = {signal.SIGINT: "SIGINT", signal.SIGQUIT: "SIGQUIT", signal.SIGTERM: 
 
 
 def sigterm_handler(sig_received, frame):  # noqa: ARG001
-    msg = "received %s(%d)" % (sig_name[sig_received], sig_received)
+    msg = f"received {sig_name[sig_received]}({sig_received})"
     # logger.debug( "SIGTERM received")
     logger.info(msg)
     LiveDataManager.stop()

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -1,3 +1,4 @@
+# Standard library imports
 import json
 import logging
 import os
@@ -7,10 +8,12 @@ import threading
 import time
 from hashlib import md5
 
+# Third-party imports
 import mantid  # for clearer error message
 import psutil
 import pyinotify
-from mantid.simpleapi import StartLiveData, mtd
+from mantid.kernel import InstrumentInfo
+from mantid.simpleapi import mtd, StartLiveData
 from mantid.utils.logging import log_to_python as mtd_log_to_python
 from packaging.version import parse as parse_version
 
@@ -161,7 +164,7 @@ class Config:
             self.logger.error("General error while importing " "mantid.kernel.ConfigService:", exc_info=True)
             raise
 
-        self.instrument = self.__getInstrument(json_doc.get("instrument"))
+        self.instrument = self.__getSetInstrument(json_doc.get("instrument"))
         self.logger.info(f'self.instrument="{self.instrument}"')
         self.updateEvery = int(json_doc.get("update_every", 30))  # in seconds
         self.preserveEvents = json_doc.get("preserve_events", True)
@@ -185,7 +188,30 @@ class Config:
         self.__determineScriptNames()
         self.logger.info(f"bottom of Config.__init__({filename})")
 
-    def __getInstrument(self, instrument):
+    def __getSetInstrument(self, instrument: str) -> InstrumentInfo:
+        """
+        Retrieves the Mantid instrument info object.
+
+        Also updates the default facility and instrument in the Mantid configuration service if they happen
+        to be different than those defined by argument `instrument`.
+
+        Parameters
+        ----------
+        instrument : str
+            The name of the instrument to set. If None, the instrument in Mantid configuration service is used.
+
+        Returns
+        -------
+        InstrumentInfo
+            The instrument information object.
+
+        Raises
+        ------
+        ImportError
+            If the Mantid ConfigService cannot be imported.
+        RuntimeError
+            If there is a general error while getting the instrument.
+        """
         try:
             from mantid.kernel import ConfigService
 
@@ -194,12 +220,17 @@ class Config:
                 return ConfigService.getInstrument()
             else:
                 self.logger.info("Converting instrument using ConfigService")
-                instrument = ConfigService.getInstrument(str(instrument))
-                facility = instrument.facility().name()
-                # set the facility if it isn't the default
+                instrument_instance = ConfigService.getInstrument(str(instrument))
+                facility = instrument_instance.facility().name()
+                # set the facility if not the default
                 if facility != ConfigService.getFacility().name():
                     ConfigService.setFacility(facility)
-                return instrument
+                    self.logger.info(f"Default Facility set to {str(facility)}")
+                # set the instrument if not the default. Prefer `str(inst)` over `inst.name()`
+                if str(instrument_instance) != str(ConfigService.getInstrument()):
+                    ConfigService["default.instrument"] = str(instrument_instance)
+                    self.logger.info(f"Default Instrument set to {str(instrument_instance)}")
+                return instrument_instance
         except ImportError:
             self.logger.error("Failed to import mantid.ConfigService", exc_info=True)
             raise

--- a/test/README.md
+++ b/test/README.md
@@ -1,14 +1,19 @@
-This should be a fully working example. All that you need is to add a
-working version of mantid. Please note that the server and client need
-to be started separately and are configured to be executed with the
-conda environment activated
+This should be a fully working example. Create a conda
+environment `livereduce` with the required dependencies (specially package `mantid`).
+Please note that the server and client need to be started separately in corresponding terminals,
+and are configured to be executed with the `livereduction` conda environment activated.
+
 
 Start Live Data Server
 ----------------------
 
-This is done by running
+From the root of the repository, on a terminal run:
 ```
-$ mantidpython --classic test/fake_server.py
+(livereduction)$ mantidpython --classic test/fake_server.py
+```
+if you did not install mantid's `workbench` (no `mantidpython` command) but just the mantid backend, run:
+```
+(livereduction)$ python test/fake_server.py
 ```
 Unfortunately, there is not currently a clean way to shutdown the
 process. `kill -9 <pid>` is the current suggestion.
@@ -16,10 +21,15 @@ process. `kill -9 <pid>` is the current suggestion.
 Start Live Processing
 ---------------------
 
-Similarly to the server
+Similarly to the server, on a different terminal run:
 ```
-$ PATH=$PATH:/path/with/nsd-app-wrap scripts/livereduce.sh test/fake.conf
+(livereduction)$ PATH=$PATH:/path/with/nsd-app-wrap scripts/livereduce.sh test/fake.conf
 ```
+If you don't have access to nsd-app-wrap, run instead:
+```
+(livereduction)$ python scripts/livereduce.py test/fake.conf --test
+```
+
 Once the first chunk of live data is processed, `ctrl-C` will
 interrupt the process and it will close cleanly.
 


### PR DESCRIPTION
Update the default instrument at the same time when the default facility is updated.

**Manual Test:**
Follow the [instructions](https://github.com/mantidproject/livereduce/blob/update_config_with_instrument/test/README.md) to manually start the live data server and the autoreduction server. Then make sure the default instrument is set by:
```bash
 grep "Default Instrument" livereduce.log 
livereduce.log:9:2025-02-10 16:12:28,303 - livereduce.Config - INFO - Default Instrument set to ISIS_Histogram
```