### PR TITLE
Make processing script optional

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -36,6 +36,12 @@ interrupt the process and it will close cleanly.
 In testing mode, the logging will go to `${PWD}/livereduce.log` and can be watched with `tail -F livereduce.log`
 
 
+Testing with post processing script
+----------------------------------
+
+An example using only a post-processing script can be tested using the `test/postprocessing/fake.conf`.
+
+
 Example using event data, to test memory monitoring
 ----------------------------------------------------
 

--- a/test/postprocessing/fake.conf
+++ b/test/postprocessing/fake.conf
@@ -1,0 +1,8 @@
+{
+  "instrument": "ISIS_Histogram",
+  "script_dir": "test/postprocessing",
+  "update_every": 3,
+  "CONDA_ENV": "livereduce",
+  "accum_method":"Replace",
+  "periods":[1,3]
+}

--- a/test/postprocessing/reduce_ISIS_Histogram_live_post_proc.py
+++ b/test/postprocessing/reduce_ISIS_Histogram_live_post_proc.py
@@ -1,0 +1,3 @@
+from mantid.simpleapi import RenameWorkspace
+
+RenameWorkspace("accumulation", "result")


### PR DESCRIPTION
This checks that you provide at least one of ProcessingScriptFilename and/or PostProcessingScriptFilename.

To test start the fake data server `python test/fake_server.py` then run livereduce with the new test configuration `scripts/livereduce.py test/postprocessing/fake.conf`.

Ref [11433: [LIVEREDUCE] Allow optional processing script](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/11433)