### PR TITLE
Add `quick_check.sh` script for RPM spec validation

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,6 +8,16 @@ on:
     tags: ['v*']
 
 jobs:
+  rpm-quick-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Make quick_check.sh executable
+      run: chmod +x test/rpm/quick_check.sh
+    - name: Run RPM spec quick check
+      run: ./test/rpm/quick_check.sh
+
   python-build:
     runs-on: ubuntu-latest
     steps:

--- a/test/rpm/quick_check.sh
+++ b/test/rpm/quick_check.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Quick validation script for LiveReduce RPM spec file changes
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Dynamically find the spec file relative to this script
+SPEC_FILE="$(dirname "$(dirname "$(realpath "$0")")")/livereduce.spec"
+
+echo -e "${BLUE}===============================================${NC}"
+echo -e "${BLUE}    LiveReduce RPM Spec File Quick Check     ${NC}"
+echo -e "${BLUE}===============================================${NC}\n"
+
+# Check if spec file exists
+if [[ ! -f "$SPEC_FILE" ]]; then
+    echo -e "${RED}✗ Spec file not found at $SPEC_FILE${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Spec file found${NC}"
+
+# Check for systemd-rpm-macros build requirement
+if grep -q "BuildRequires:.*systemd-rpm-macros" "$SPEC_FILE"; then
+    echo -e "${GREEN}✓ BuildRequires systemd-rpm-macros${NC}"
+else
+    echo -e "${RED}✗ Missing BuildRequires systemd-rpm-macros${NC}"
+    exit 1
+fi
+
+# Check for user requirements
+if grep -q "Requires:.*user(snsdata)" "$SPEC_FILE"; then
+    echo -e "${GREEN}✓ Requires user(snsdata)${NC}"
+else
+    echo -e "${RED}✗ Missing user(snsdata) requirement${NC}"
+    exit 1
+fi
+
+# Check for group requirements
+if grep -q "Requires:.*group(users)" "$SPEC_FILE"; then
+    echo -e "${GREEN}✓ Requires group(users)${NC}"
+else
+    echo -e "${RED}✗ Missing group(users) requirement${NC}"
+    exit 1
+fi
+
+if grep -q "Requires:.*group(hfiradmin)" "$SPEC_FILE"; then
+    echo -e "${GREEN}✓ Requires group(hfiradmin)${NC}"
+else
+    echo -e "${RED}✗ Missing group(hfiradmin) requirement${NC}"
+    exit 1
+fi
+
+# Check for systemd scriptlets
+if grep -q "%systemd_post.*livereduce.service" "$SPEC_FILE"; then
+    echo -e "${GREEN}✓ %systemd_post scriptlet${NC}"
+else
+    echo -e "${RED}✗ Missing %systemd_post scriptlet${NC}"
+    exit 1
+fi
+
+if grep -q "%systemd_preun.*livereduce.service" "$SPEC_FILE"; then
+    echo -e "${GREEN}✓ %systemd_preun scriptlet${NC}"
+else
+    echo -e "${RED}✗ Missing %systemd_preun scriptlet${NC}"
+    exit 1
+fi
+
+if grep -q "%systemd_postun_with_restart.*livereduce.service" "$SPEC_FILE"; then
+    echo -e "${GREEN}✓ %systemd_postun_with_restart scriptlet${NC}"
+else
+    echo -e "${RED}✗ Missing %systemd_postun_with_restart scriptlet${NC}"
+    exit 1
+fi
+
+# Check service file
+SERVICE_FILE="$(dirname "$(dirname "$(realpath "$0")")")/livereduce.service"
+if [[ -f "$SERVICE_FILE" ]]; then
+    echo -e "${GREEN}✓ Service file exists${NC}"
+
+    if grep -q "User=snsdata" "$SERVICE_FILE"; then
+        echo -e "${GREEN}✓ Service runs as snsdata user${NC}"
+    else
+        echo -e "${RED}✗ Service not configured to run as snsdata${NC}"
+        exit 1
+    fi
+else
+    echo -e "${RED}✗ Service file not found${NC}"
+    exit 1
+fi
+
+echo -e "\n${GREEN}🎉 All RPM improvements are correctly implemented!${NC}"
+echo -e "\n${YELLOW}Summary of changes:${NC}"
+echo "• Added systemd-rpm-macros build requirement"
+echo "• Added user(snsdata) requirement"
+echo "• Added group(users) requirement"
+echo "• Added group(hfiradmin) requirement"
+echo "• Added %systemd_post scriptlet for service installation"
+echo "• Added %systemd_preun scriptlet for service removal"
+echo "• Added %systemd_postun_with_restart scriptlet for automatic restart on upgrade"
+
+echo -e "\n${BLUE}Next steps:${NC}"
+echo "1. Install build prerequisites: ./test/rpm/setup_test_environment.sh"
+echo "2. Build and test RPM: ./test/rpm/build_and_test.sh"
+echo "3. Run manual tests: ./test/rpm/test_manual_rpm.sh"

--- a/test/rpm/quick_check.sh
+++ b/test/rpm/quick_check.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 # Quick validation script for LiveReduce RPM spec file changes
 
-set -e
-
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/test/rpm/quick_check.sh
+++ b/test/rpm/quick_check.sh
@@ -11,7 +11,10 @@ BLUE='\033[0;34m'
 NC='\033[0m'
 
 # Dynamically find the spec file relative to this script
-SPEC_FILE="$(dirname "$(dirname "$(realpath "$0")")")/livereduce.spec"
+# Script is at test/rpm/quick_check.sh, spec is at project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SPEC_FILE="$PROJECT_ROOT/livereduce.spec"
 
 echo -e "${BLUE}===============================================${NC}"
 echo -e "${BLUE}    LiveReduce RPM Spec File Quick Check     ${NC}"
@@ -79,7 +82,7 @@ else
 fi
 
 # Check service file
-SERVICE_FILE="$(dirname "$(dirname "$(realpath "$0")")")/livereduce.service"
+SERVICE_FILE="$PROJECT_ROOT/livereduce.service"
 if [[ -f "$SERVICE_FILE" ]]; then
     echo -e "${GREEN}✓ Service file exists${NC}"
 


### PR DESCRIPTION
### Description:
This PR adds a quick validation script for the RPM spec file along with CI integration.

### What's added
- `test/rpm/quick_check.sh` - Fast validation of spec file requirements
- CI job that runs the script on all PRs and pushes

### What it checks
- systemd-rpm-macros build requirement
- user(snsdata) and group requirements
- systemd scriptlets (%systemd_post, %systemd_preun, %systemd_postun_with_restart)
- Service file configuration

### Why this approach
Following the suggestion to break down the testing framework into smaller, focused PRs. This is the first piece - a quick validation that can run in CI to catch spec file issues early.

Related to [#24](https://github.com/mantidproject/livereduce/pull/24) (merged spec file improvements)
Part of the RPM testing framework (see [#26](https://github.com/mantidproject/livereduce/pull/26) for full context)