### PR TITLE
Update instructions for running local tests within pixi

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ pixi shell
 pre-commit install
 ```
 
+More information about testing can be found in [test/README.md](test/README.md).
+
 Acknowledgements and other links
 --------------------------------
 Information and ideas taken from:

--- a/test/README.md
+++ b/test/README.md
@@ -10,11 +10,7 @@ Start Live Data Server
 
 From the root of the repository, on a terminal run:
 ```
-(livereduction)$ mantidpython --classic test/fake_server.py
-```
-if you did not install mantid's `workbench` (no `mantidpython` command) but just the mantid backend, run:
-```
-(livereduction)$ python test/fake_server.py
+(livereduction)$ pixi run python test/fake_server.py
 ```
 Unfortunately, there is not currently a clean way to shutdown the
 process. `kill -9 <pid>` is the current suggestion.
@@ -28,7 +24,7 @@ Similarly to the server, on a different terminal run:
 ```
 If you don't have access to nsd-app-wrap, run instead:
 ```
-(livereduction)$ python scripts/livereduce.py test/fake.conf --test
+(livereduction)$ pixi run python scripts/livereduce.py test/fake.conf
 ```
 
 Once the first chunk of live data is processed, `ctrl-C` will


### PR DESCRIPTION
This updates the documentation for running tests locally within pixi. The tests are not being added to CI because there is not a clear way to shutdown the process after a period of time.