### PR TITLE
Add job for running rpmlint

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         echo "This passes with warnings"
         docker load --input ${{ runner.temp }}/rpmlint.tar
-        docker run  -v ./livereduce.spec:/tmp/livereduce.spec neutrons/rpmlint:latest rpmlint -i  /tmp/livereduce.spec
+        docker run -v ./livereduce.spec:/tmp/livereduce.spec neutrons/rpmlint:latest rpmlint -i  /tmp/livereduce.spec
 
   rpm:
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -35,12 +35,21 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Builder docker image
-      run: docker build -f Dockerfile.rpmlint -t rpmlint .
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v6
+      with:
+        file: Dockerfile.rpmlint
+        tags: neutrons/rpmlint:latest
+        outputs: type=docker,dest=${{ runner.temp }}/rpmlint.tar
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
     - name: Lint rpm
       run: |
         echo "This passes with warnings"
-        docker run  -v ./livereduce.spec:/tmp/livereduce.spec rpmlint:latest rpmlint -i  /tmp/livereduce.spec
+        docker load --input ${{ runner.temp }}/rpmlint.tar
+        docker run  -v ./livereduce.spec:/tmp/livereduce.spec neutrons/rpmlint:latest rpmlint -i  /tmp/livereduce.spec
 
   rpm:
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -30,6 +30,18 @@ jobs:
         pixi run build
         # the package isn't built because this is a unusual package
 
+  rpmlint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Builder docker image
+      run: docker build -f Dockerfile.rpmlint -t rpmlint .
+    - name: Lint rpm
+      run: |
+        echo "This passes with warnings"
+        docker run  -v ./livereduce.spec:/tmp/livereduce.spec rpmlint:latest rpmlint -i  /tmp/livereduce.spec
+
   rpm:
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile.rpmlint
+++ b/Dockerfile.rpmlint
@@ -4,7 +4,7 @@ FROM registry.access.redhat.com/ubi9/ubi
 USER root
 WORKDIR /root
 
-RUN dnf install -y rpmdevtools rpmlint vim
+RUN dnf install -y rpmdevtools rpmlint
 
 RUN useradd builder
 USER builder

--- a/Dockerfile.rpmlint
+++ b/Dockerfile.rpmlint
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+FROM registry.access.redhat.com/ubi9/ubi
+
+USER root
+WORKDIR /root
+
+RUN dnf install -y rpmdevtools rpmlint vim
+
+RUN useradd builder
+USER builder
+WORKDIR /home/builder
+
+# create rpmlint configuration
+RUN mkdir -p ./.config
+RUN echo "addFilter('invalid-url Source')" > ./.config/rpmlint
+
+RUN rpmdev-setuptree


### PR DESCRIPTION
Add build job for running rpmlint for major issues. Warnings are printed, but does not fail the job. Errors do.

This is doing things using docker's actions for building images. Related docs:
* [cache management](https://docs.docker.com/build/ci/github-actions/cache/)
* [share images between jobs](https://docs.docker.com/build/ci/github-actions/share-image-jobs/)