### PR TITLE
Update default memory limit from 25% to 70%

### DIFF
--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -171,7 +171,7 @@ class Config:
         self.accumMethod = str(json_doc.get("accum_method", "Add"))
         self.periods = json_doc.get("periods", None)
         self.spectra = json_doc.get("spectra", None)
-        self.system_mem_limit_perc = json_doc.get("system_mem_limit_perc", 25)  # set to 0 to disable
+        self.system_mem_limit_perc = json_doc.get("system_mem_limit_perc", 70)  # set to 0 to disable
         self.mem_check_interval_sec = json_doc.get("mem_check_interval_sec", 1)
         self.mem_limit = psutil.virtual_memory().total * self.system_mem_limit_perc / 100
         self.proc_pid = psutil.Process(os.getpid())

--- a/test/fake_event.conf
+++ b/test/fake_event.conf
@@ -4,6 +4,6 @@
   "update_every": 3,
   "CONDA_ENV": "livereduce",
   "accum_method":"Add",
-  "system_mem_limit_perc": 25,
+  "system_mem_limit_perc": 70,
   "mem_check_interval_sec": 1
 }


### PR DESCRIPTION
### Description
This is more appropriate for dedicated machines where the livereduce daemon typically runs and aligns with autoreduction's default configuration.

### Changes
- Updated default `system_mem_limit_perc` from 25 to 70 in `scripts/livereduce.py`
- Updated test configuration `test/fake_event.conf` to reflect the new default

Existing configurations that explicitly set a memory limit will not be affected by this change.

###References:
[EWM 13608](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=13608)