### PR TITLE
Add watchdog functionality to monitor and restart livereduce service

### DIFF
--- a/livereduce_watchdog.service
+++ b/livereduce_watchdog.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Livereduction Watchdog
+
+[Service]
+WorkingDirectory=/tmp
+User=snsdata
+ExecStart=/usr/bin/livereduce_watchdog.sh
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/livereduce_watchdog.service
+++ b/livereduce_watchdog.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Livereduction Watchdog
+After=livereduce.service
 
 [Service]
 WorkingDirectory=/tmp

--- a/livereduce_watchdog.service
+++ b/livereduce_watchdog.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Livereduction Watchdog
+Description=Livereduce Watchdog
 After=livereduce.service
 
 [Service]

--- a/scripts/livereduce_watchdog.sh
+++ b/scripts/livereduce_watchdog.sh
@@ -44,7 +44,7 @@ last_restart=0
 while true; do
 
   if [[ ! -e "$WATCHDOG_TARGET" ]]; then
-    echo "$(date '+%F %T') ERROR: '$WATCHDOG_TARGET' not found." >> "$WATCHDOG_LOG"
+    echo "$(date --iso-8601=seconds) ERROR: '$WATCHDOG_TARGET' not found." >> "$WATCHDOG_LOG"
 
   else
     # Get file mtime (epoch seconds) and current time
@@ -58,20 +58,18 @@ while true; do
       if (( since_restart >= THRESHOLD )); then
         {
           echo -e "\n#############################################################################"
-          echo "$(date '+%F %T') No change for $age s in $WATCHDOG_TARGET"
+          echo "$(date --iso-8601=seconds) No change for $age s in $WATCHDOG_TARGET"
           echo "---- Last 20 lines of $WATCHDOG_TARGET before restart:"
           tail -n 20 "$WATCHDOG_TARGET"
           echo -e "\nrestarting $MANAGED_SERVICE."
         } >> "$WATCHDOG_LOG"
         # Restart the service (use systemctl or service as appropriate)
         if command -v systemctl &>/dev/null; then
-          systemctl stop "$MANAGED_SERVICE"
-          systemctl start "$MANAGED_SERVICE"
+          systemctl restart "$MANAGED_SERVICE"
           sleep 5 # give it a moment to start
           systemctl status "$MANAGED_SERVICE" >> "$WATCHDOG_LOG"
         else
-          service "$MANAGED_SERVICE" stop
-          service "$MANAGED_SERVICE" start
+          service "$MANAGED_SERVICE" restart
           sleep 5 # give it a moment to start
           service "$MANAGED_SERVICE" status >> "$WATCHDOG_LOG"
         fi

--- a/scripts/livereduce_watchdog.sh
+++ b/scripts/livereduce_watchdog.sh
@@ -51,10 +51,12 @@ while true; do
         if command -v systemctl &>/dev/null; then
           systemctl stop "$MANAGED_SERVICE"
           systemctl start "$MANAGED_SERVICE"
+          sleep 5 # give it a moment to start
           systemctl status "$MANAGED_SERVICE" >> "$WATCHDOG_LOG"
         else
           service "$MANAGED_SERVICE" stop
-          service "$MANAGED_SERVICE" start >> "$WATCHDOG_LOG"
+          service "$MANAGED_SERVICE" start
+          sleep 5 # give it a moment to start
           service "$MANAGED_SERVICE" status >> "$WATCHDOG_LOG"
         fi
         last_restart=$now

--- a/scripts/livereduce_watchdog.sh
+++ b/scripts/livereduce_watchdog.sh
@@ -19,6 +19,7 @@ WATCHDOG_TARGET="/var/log/SNS_applications/livereduce.log"
 MANAGED_SERVICE="livereduce.service"
 # Default values
 DEFAULT_INTERVAL=60
+MINIMUM_THRESHOLD=20  # Maximum allotted time to restart the livereduce service
 DEFAULT_THRESHOLD=300
 # How often we check WATCHDOG_TARGET. Default is 60 seconds.
 INTERVAL="$(/bin/jq --raw-output '.watchdog.interval // 60' "${CONFIG_FILE}")"
@@ -30,8 +31,8 @@ if ! [[ "$INTERVAL" =~ ^[1-9][0-9]*$ ]]; then
   echo "WARNING: Invalid INTERVAL value '$INTERVAL'. Using default: $DEFAULT_INTERVAL" >&2
   INTERVAL=$DEFAULT_INTERVAL
 fi
-# Validate THRESHOLD is a positive integer, otherwise use default
-if ! [[ "$THRESHOLD" =~ ^[1-9][0-9]*$ ]]; then
+# Validate THRESHOLD is a positive integer and larger or equal to MINIMUM_THRESHOLD, otherwise use default
+if ! [[ "$THRESHOLD" =~ ^[1-9][0-9]*$ ]] || (( THRESHOLD < MINIMUM_THRESHOLD )); then
   echo "WARNING: Invalid THRESHOLD value '$THRESHOLD'. Using default: $DEFAULT_THRESHOLD" >&2
   THRESHOLD=$DEFAULT_THRESHOLD
 fi

--- a/scripts/livereduce_watchdog.sh
+++ b/scripts/livereduce_watchdog.sh
@@ -17,10 +17,24 @@ fi
 # --- CONFIG ---
 WATCHDOG_TARGET="/var/log/SNS_applications/livereduce.log"
 MANAGED_SERVICE="livereduce.service"
+# Default values
+DEFAULT_INTERVAL=60
+DEFAULT_THRESHOLD=300
 # How often we check WATCHDOG_TARGET. Default is 60 seconds.
 INTERVAL="$(/bin/jq --raw-output '.watchdog.interval // 60' "${CONFIG_FILE}")"
 # Inactivity threshold. Default is 300 seconds.
 THRESHOLD="$(/bin/jq --raw-output '.watchdog.threshold // 300' "${CONFIG_FILE}")"
+
+# Validate INTERVAL is a positive integer, otherwise use default
+if ! [[ "$INTERVAL" =~ ^[1-9][0-9]*$ ]]; then
+  echo "WARNING: Invalid INTERVAL value '$INTERVAL'. Using default: $DEFAULT_INTERVAL" >&2
+  INTERVAL=$DEFAULT_INTERVAL
+fi
+# Validate THRESHOLD is a positive integer, otherwise use default
+if ! [[ "$THRESHOLD" =~ ^[1-9][0-9]*$ ]]; then
+  echo "WARNING: Invalid THRESHOLD value '$THRESHOLD'. Using default: $DEFAULT_THRESHOLD" >&2
+  THRESHOLD=$DEFAULT_THRESHOLD
+fi
 
 WATCHDOG_LOG="/var/log/SNS_applications/livereduce_watchdog.log"
 # Track when we last issued a restart so we don't keep restarting every loop

--- a/scripts/livereduce_watchdog.sh
+++ b/scripts/livereduce_watchdog.sh
@@ -42,11 +42,13 @@ while true; do
       # Only restart if we haven't already done so in this inactivity window
       since_restart=$(( now - last_restart ))
       if (( since_restart >= THRESHOLD )); then
-        echo -e "\n#############################################################################" >> "$WATCHDOG_LOG"
-        echo "$(date '+%F %T') No change for $age s in $WATCHDOG_TARGET" >> "$WATCHDOG_LOG"
-        echo "---- Last 20 lines of $WATCHDOG_TARGET before restart:" >> "$WATCHDOG_LOG"
-        tail -n 20 "$WATCHDOG_TARGET" >> "$WATCHDOG_LOG"
-        echo -e "\nrestarting $MANAGED_SERVICE." >> "$WATCHDOG_LOG"
+        {
+          echo -e "\n#############################################################################"
+          echo "$(date '+%F %T') No change for $age s in $WATCHDOG_TARGET"
+          echo "---- Last 20 lines of $WATCHDOG_TARGET before restart:"
+          tail -n 20 "$WATCHDOG_TARGET"
+          echo -e "\nrestarting $MANAGED_SERVICE."
+        } >> "$WATCHDOG_LOG"
         # Restart the service (use systemctl or service as appropriate)
         if command -v systemctl &>/dev/null; then
           systemctl stop "$MANAGED_SERVICE"

--- a/scripts/livereduce_watchdog.sh
+++ b/scripts/livereduce_watchdog.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "ARGS $*"
 
-# determine the configuration file.
+# determine the configuration file
 if [ $# -ge 1 ]; then
     CONFIG_FILE="${1}"
 else

--- a/test/fake.conf
+++ b/test/fake.conf
@@ -4,5 +4,9 @@
   "update_every": 3,
   "CONDA_ENV": "livereduce",
   "accum_method":"Replace",
-  "periods":[1,3]
+  "periods":[1,3],
+  "watchdog": {
+    "interval": 60,
+    "threshold": 300
+  }
 }


### PR DESCRIPTION
This PR adds a watchdog service to monitor the livereduce service and automatically restart it when the service becomes inactive (stops writing to its log file). The watchdog monitors file modification times and triggers service restarts when activity thresholds are exceeded.