### PR TITLE
Package the watchdog subpackage

### DIFF
--- a/livereduce.spec
+++ b/livereduce.spec
@@ -80,6 +80,7 @@ Daemon for running the algorithm StartLiveData
 
 %preun watchdog
 %systemd_preun livereduce_watchdog.service
+%{__rm} -f /var/log/SNS_applications/livereduce_watchdog.log*
 
 %postun
 %systemd_postun_with_restart livereduce.service

--- a/livereduce.spec
+++ b/livereduce.spec
@@ -5,7 +5,7 @@
 
 Summary: %{summary}
 Name: python-%{srcname}
-Version: 1.16
+Version: 1.17
 Release: %{release}%{?dist}
 Source0: %{srcname}-%{version}.tar.gz
 License: MIT
@@ -25,9 +25,17 @@ Requires: nsd-app-wrap
 Requires: systemd
 
 %description
-There should be a meaningful description, but it is not needed quite yet.
+Daemon for running the algorithm StartLiveData
 
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
+
+%package watchdog
+Summary: Watchdog for restarting livereduce daemon
+# may need to tweak the main package name as macros change
+Requires:  python-%{srcname} = %{version}-%{release}
+
+%description watchdog
+Daemon for running the algorithm StartLiveData
 
 %prep
 %setup -q -n %{srcname}-%{version}
@@ -43,6 +51,9 @@ There should be a meaningful description, but it is not needed quite yet.
 %{__install} -m 755 scripts/livereduce.sh %{buildroot}%{_bindir}/
 %{__mkdir} -p %{buildroot}%{_unitdir}/
 %{__install} -m 644 livereduce.service %{buildroot}%{_unitdir}/
+# watchdog service
+%{__install} -m 755 scripts/livereduce_watchdog.sh %{buildroot}%{_bindir}/
+%{__install} -m 644 livereduce_watchdog.service %{buildroot}%{_unitdir}/
 
 %check
 # no test step
@@ -60,15 +71,28 @@ There should be a meaningful description, but it is not needed quite yet.
 %{__chown} snsdata /var/log/SNS_applications/
 %{__chmod} 1755 /var/log/SNS_applications/
 
+%post watchdog
+%systemd_post livereduce_watchdog.service
+
 %preun
 %systemd_preun livereduce.service
 %{__rm} -f /var/log/SNS_applications/livereduce.log*
 
+%preun watchdog
+%systemd_preun livereduce_watchdog.service
+
 %postun
 %systemd_postun_with_restart livereduce.service
+
+%postun watchdog
+%systemd_postun_with_restart livereduce_watchdog.service
 
 %files
 %doc README.md
 %{_bindir}/livereduce.py
 %{_bindir}/livereduce.sh
 %{_unitdir}/livereduce.service
+
+%files watchdog
+%{_bindir}/livereduce_watchdog.sh
+%{_unitdir}/livereduce_watchdog.service

--- a/livereduce.spec
+++ b/livereduce.spec
@@ -35,7 +35,7 @@ Summary: Watchdog for restarting livereduce daemon
 Requires:  python-%{srcname} = %{version}-%{release}
 
 %description watchdog
-Daemon for running the algorithm StartLiveData
+Daemon that monitors the livereduce log file and restarts service livereduce if necessary
 
 %prep
 %setup -q -n %{srcname}-%{version}

--- a/pixi.lock
+++ b/pixi.lock
@@ -1400,8 +1400,8 @@ packages:
   timestamp: 1727963148474
 - pypi: ./
   name: livereduce
-  version: '1.16'
-  sha256: 92d5a67c1d1240db242ed1788dbc590e677caa8564e0ae3c8339f218a76027e4
+  version: '1.17'
+  sha256: 17e2a7bda8dd01f161c654fa533a435d074171e2ae13dd773b5009f24d50fd0d
   requires_python: '>=3.9'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "livereduce"
 description = "Daemon for running live data reduction with systemd"
-version="1.16"
+version="1.17"
 requires-python = ">=3.9"
 license = { text = "MIT License" }
 authors = [{name="Pete Peterson",email="petersonpf@ornl.gov"}]

--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -38,4 +38,4 @@ DIST=$(rpm --eval %{?dist})
 echo "========================================"
 echo "Successfully built rpm. To manually inspect package run"
 echo "rpm -qilRp ~/rpmbuild/RPMS/noarch/python-livereduce-${VERSION}-1${DIST}.noarch.rpm"
-echo "rpm -qilRp ~/rpmbuild/RPMS/noarch/python-livereduce-watchdog${VERSION}-1${DIST}.noarch.rpm"
+echo "rpm -qilRp ~/rpmbuild/RPMS/noarch/python-livereduce-watchdog-${VERSION}-1${DIST}.noarch.rpm"

--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -38,3 +38,4 @@ DIST=$(rpm --eval %{?dist})
 echo "========================================"
 echo "Successfully built rpm. To manually inspect package run"
 echo "rpm -qilRp ~/rpmbuild/RPMS/noarch/python-livereduce-${VERSION}-1${DIST}.noarch.rpm"
+echo "rpm -qilRp ~/rpmbuild/RPMS/noarch/python-livereduce-watchdog${VERSION}-1${DIST}.noarch.rpm"


### PR DESCRIPTION
Create a new `python-livereduce-watchdog` package for the second service. It depends on `python-livereduce` and can be optionally installed afterwards.