### PR TITLE
Transition to PIXI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,6 +18,16 @@ jobs:
     - name: Run RPM spec quick check
       run: ./test/rpm/quick_check.sh
 
+  bash-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Setup Pixi
+      uses: prefix-dev/setup-pixi@v0.9.3
+    - name: Run BATS tests
+      run: pixi run test-bash
+
   python-build:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A minimal configuration to specify using nightly builds of mantid installed in a
 ```
 For backwards compatibility, a `CONDA_ENV` variable can be specified instead of `PIXI_ENV`,
 but its value will be used to start a pixi environment, not a conda environment.
-In additions, an assignment such as `CONDA_ENV="mantid-dev"` translates to pixi environmnent `"mantid_dev"`,
+In additions, an assignment such as `CONDA_ENV="mantid-dev"` translates to pixi environment `"mantid_dev"`,
 and likewise suffix `"-qa"` translates to `"_qa"`.
 
 For testing, a configuration file can be supplied as a command line argument when running

--- a/README.md
+++ b/README.md
@@ -22,13 +22,18 @@ Configuration
 
 The configuration is automatically read from `/etc/livereduce.conf`unless specified as a command line argument.
 Defaults will be attempted to be determined from the environment.
-A minimal configuration to specify using nightly builds of mantid installed in a conda environment `mantid-dev` is
+A minimal configuration to specify using nightly builds of mantid installed in a pixi environment `mantid_dev` is
 ```json
 {
   "instrument": "PG3",
-  "CONDA_ENV": "mantid-dev"
+  "PIXI_ENV": "mantid_dev"
 }
 ```
+For backwards compatibility, a `CONDA_ENV` variable can be specified instead of `PIXI_ENV`,
+but its value will be used to start a pixi environment, not a conda environment.
+In additions, an assignment such as `CONDA_ENV="mantid-dev"` translates to pixi environmnent `"mantid_dev"`,
+and likewise suffix `"-qa"` translates to `"_qa"`.
+
 For testing, a configuration file can be supplied as a command line argument when running
 ```shell
 $ python scripts/livereduce.py ./livereduce.conf
@@ -74,8 +79,8 @@ Python processing scripts
 
 
 - [livereduce.sh](../scripts/livereduce.sh) is the script that is run when the service is started.
-  This shell script invokes `livereduce.py` within a conda environment
-  specified in the configuration file. Otherwise the environment is set to `"mantid-dev"`.
+  This shell script invokes `livereduce.py` within a pixi environment
+  specified in the configuration file. Otherwise the environment is set to `"mantid_dev"`.
 - [livereduce.py](../scripts/livereduce.py) script manages live data reduction using the Mantid framework.
   It configures logging, handles signals for graceful termination, reads the configuration JSON,
   and manages live data processing with Mantid's StartLiveData and MonitorLiveData algorithms.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 Configuration
 -------------
 
-The configuration is automatically read from `/etc/livereduce.conf`unless specified as a command line argument.
+The configuration is automatically read from `/etc/livereduce.conf` unless specified as a command line argument.
 Defaults will be attempted to be determined from the environment.
 A minimal configuration to specify using nightly builds of mantid installed in a pixi environment `mantid_dev` is
 ```json

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A minimal configuration to specify using nightly builds of mantid installed in a
 ```
 For backwards compatibility, a `CONDA_ENV` variable can be specified instead of `PIXI_ENV`,
 but its value will be used to start a pixi environment, not a conda environment.
-In additions, an assignment such as `CONDA_ENV="mantid-dev"` translates to pixi environment `"mantid_dev"`,
+In addition, an assignment such as `CONDA_ENV="mantid-dev"` translates to pixi environment `"mantid_dev"`,
 and likewise suffix `"-qa"` translates to `"_qa"`.
 
 For testing, a configuration file can be supplied as a command line argument when running

--- a/pixi.lock
+++ b/pixi.lock
@@ -13,6 +13,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bats-core-1.13.0-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.10.5-hbd8a1cb_0.conda
@@ -218,6 +219,14 @@ packages:
   - pkg:pypi/argcomplete?source=hash-mapping
   size: 42386
   timestamp: 1760975036972
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bats-core-1.13.0-ha770c72_0.conda
+  sha256: fab4ddcbe6769acf4c2e28e474cb40d1d7dc17c78fef9c248230ed4dbb7fea96
+  md5: 09b12d1a94df246266ab95a7a2fe9d35
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 48710
+  timestamp: 1762537439832
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
   sha256: c30daba32ddebbb7ded490f0e371eae90f51e72db620554089103b4a6934b0d5
   md5: 51a19bba1b8ebfb60df25cde030b7ebc
@@ -1401,7 +1410,7 @@ packages:
 - pypi: ./
   name: livereduce
   version: '1.17'
-  sha256: 17e2a7bda8dd01f161c654fa533a435d074171e2ae13dd773b5009f24d50fd0d
+  sha256: efd34d3f175bb1bfe642d8c66e5d52e2aea0d9897c87c9cfd4b8354a40dd0830
   requires_python: '>=3.9'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,11 @@ channels = ["conda-forge", "mantid", "https://prefix.dev/pixi-build-backends"]
 platforms = ["linux-64"]
 preview = ["pixi-build"]
 
+[tool.pixi.environments]
+default = { features = [
+  "test",
+], solve-group = "default" }
+
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "0.1.*" }
 
@@ -36,5 +41,11 @@ argcomplete = ">=3.6.3,<4"
 [tool.pixi.pypi-dependencies]
 livereduce = { path = ".", editable = true }
 
+[tool.pixi.feature.test.dependencies]
+bats-core = "*"
+
 [tool.pixi.tasks]
 build = "hatchling build -t sdist"
+
+[tool.pixi.feature.test.tasks]
+test-bash = "bats test/test_livereduce.bats"

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -151,8 +151,9 @@ class Config:
         self.logger.info("Finished parsing configuration")
 
         # log the pixi environment and mantid's location. Search CONDA_ENV first for backward compatibility
-        self.pixi_env = json_doc.get("CONDA_ENV", "mantid_dev").replace("-dev", "_dev").replace("-qa", "_qa")
+        self.pixi_env = json_doc.get("CONDA_ENV", "mantid_dev")
         self.pixi_env = json_doc.get("PIXI_ENV", self.pixi_env)
+        self.pixi_env = self.pixi_env.replace("-dev", "_dev").replace("-qa", "_qa")
         self.logger.info(f"PIXI_ENV = {self.pixi_env}")
         self.logger.info(f'mantid_loc="{os.path.dirname(mantid.__file__)}"')
 

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -129,7 +129,7 @@ class Config:
     r"""
     Configuration stored in json format. The keys are:
     * 'instrument' - default from ~/.mantid/Mantid.user.properties
-    * 'CONDA_ENV' - if not specified, defaults to 'mantid-dev'
+    * 'PIXI_ENV' - if not specified, defaults to 'mantid_dev'
     * 'script_dir' - default value is '/SNS/{instrument}/shared/livereduce'
     """
 
@@ -150,9 +150,10 @@ class Config:
             json_doc = dict()
         self.logger.info("Finished parsing configuration")
 
-        # log the conda environment and mantid's location
-        self.conda_env = json_doc.get("CONDA_ENV", "mantid-dev")
-        self.logger.info(f"CONDA_ENV = {self.conda_env}")
+        # log the pixi environment and mantid's location. Search CONDA_ENV first for backward compatibility
+        self.pixi_env = json_doc.get("CONDA_ENV", "mantid_dev").replace("-dev", "_dev").replace("-qa", "_qa")
+        self.pixi_env = json_doc.get("PIXI_ENV", self.pixi_env)
+        self.logger.info(f"PIXI_ENV = {self.pixi_env}")
         self.logger.info(f'mantid_loc="{os.path.dirname(mantid.__file__)}"')
 
         try:
@@ -313,7 +314,7 @@ class Config:
     def toJson(self, **kwargs):
         args = dict(
             instrument=self.instrument.shortName(),
-            CONDA_ENV=self.conda_env,
+            PIXI_ENV=self.pixi_env,
             script_dir=self.script_dir,
             update_every=self.updateEvery,
             preserve_events=self.preserveEvents,

--- a/scripts/livereduce.sh
+++ b/scripts/livereduce.sh
@@ -32,8 +32,8 @@ rm -f "${HOME}"/.cache/fontconfig/*
 THISFILE=$(readlink -f "$0")  # absolute path of this script
 INSTALLDIR=$(dirname "${THISFILE}")
 APPLICATION="${INSTALLDIR}/livereduce.py"
-NSD_APP_WRAP="${INSTALLDIR}/nsd-app-wrap.sh"  # assumes nsd-app-wrap.sh in the same directory
-if [ ! -f "${NSD_APP_WRAP}" ]; then
+NSD_APP_WRAP="$(which nsd-app-wrap.sh 2>/dev/null || true)"
+if [ -z "${NSD_APP_WRAP}" ]; then
     echo "Failed to find nsd-app-wrap.sh"
     exit 1
 fi

--- a/scripts/livereduce.sh
+++ b/scripts/livereduce.sh
@@ -8,27 +8,36 @@ else
     CONFIG_FILE=/etc/livereduce.conf
 fi
 
-# determine the conda environment
-CONDA_ENVIRON="mantid-dev"  # default
+# determine the pixi environment
+PIXI_ENVIRON="mantid_dev"  # default
 if [ -f "${CONFIG_FILE}" ]; then
-    if grep -q CONDA_ENV "${CONFIG_FILE}"; then
-        echo "Determine conda environment from \"${CONFIG_FILE}"\"
+    if grep -q PIXI_ENV "${CONFIG_FILE}"; then
+        echo "Determine pixi environment from \"${CONFIG_FILE}\""
+        PIXI_ENVIRON="$(/bin/jq --raw-output '.PIXI_ENV' "${CONFIG_FILE}")"
+    elif grep -q CONDA_ENV "${CONFIG_FILE}"; then  # backward compatibility
+        echo "Determine pixi environment from CONDA_ENV entry in \"${CONFIG_FILE}\""
         CONDA_ENVIRON="$(/bin/jq --raw-output '.CONDA_ENV' "${CONFIG_FILE}")"
+        if [[ "${CONDA_ENVIRON}" == *-dev ]]; then  # substitute dash for underscore in dev/qa suffix
+            PIXI_ENVIRON="${CONDA_ENVIRON%-dev}_dev"
+        elif [[ "${CONDA_ENVIRON}" == *-qa ]]; then
+            PIXI_ENVIRON="${CONDA_ENVIRON%-qa}_qa"
+        fi
     fi
 fi
 
 # remove font-cache to side step startup speed issue
 rm -f "${HOME}"/.cache/fontconfig/*
 
-# location of this script
-THISFILE=$(readlink -f "$0")
-INSTALLDIR=$(dirname "${THISFILE}")   # directory of executable
-
-# launch the application using nsd-conda-wrap.sh
-NSD_CONDA_WRAP=$(which nsd-conda-wrap.sh)
-if [ -z "${NSD_CONDA_WRAP}" ];then
-    echo "Failed to find nsd-conda-wrap.sh"
+# location of livereduce.py and nsd-app-wrap.sh
+THISFILE=$(readlink -f "$0")  # absolute path of this script
+INSTALLDIR=$(dirname "${THISFILE}")
+APPLICATION="${INSTALLDIR}/livereduce.py"
+NSD_APP_WRAP="${INSTALLDIR}/nsd-app-wrap.sh"  # assumes nsd-app-wrap.sh in the same directory
+if [ -z "${NSD_APP_WRAP}" ];then
+    echo "Failed to find nsd-app-wrap.sh"
     exit 1
 fi
-APPLICATION="${INSTALLDIR}/livereduce.py"
-exec "${NSD_CONDA_WRAP}" "${CONDA_ENVIRON}" --classic python3 "${APPLICATION}" "$@"
+
+# launch livereduce.py
+. "${NSD_APP_WRAP}"  # load bash function `pixi_launch`
+pixi_launch "${PIXI_ENVIRON}" python "${APPLICATION}" "$@"

--- a/scripts/livereduce.sh
+++ b/scripts/livereduce.sh
@@ -33,7 +33,7 @@ THISFILE=$(readlink -f "$0")  # absolute path of this script
 INSTALLDIR=$(dirname "${THISFILE}")
 APPLICATION="${INSTALLDIR}/livereduce.py"
 NSD_APP_WRAP="${INSTALLDIR}/nsd-app-wrap.sh"  # assumes nsd-app-wrap.sh in the same directory
-if [ -z "${NSD_APP_WRAP}" ];then
+if [ ! -f "${NSD_APP_WRAP}" ]; then
     echo "Failed to find nsd-app-wrap.sh"
     exit 1
 fi

--- a/scripts/livereduce.sh
+++ b/scripts/livereduce.sh
@@ -21,6 +21,8 @@ if [ -f "${CONFIG_FILE}" ]; then
             PIXI_ENVIRON="${CONDA_ENVIRON%-dev}_dev"
         elif [[ "${CONDA_ENVIRON}" == *-qa ]]; then
             PIXI_ENVIRON="${CONDA_ENVIRON%-qa}_qa"
+        else
+            PIXI_ENVIRON="${CONDA_ENVIRON}"
         fi
     fi
 fi

--- a/scripts/livereduce.sh
+++ b/scripts/livereduce.sh
@@ -16,13 +16,11 @@ if [ -f "${CONFIG_FILE}" ]; then
         PIXI_ENVIRON="$(/bin/jq --raw-output '.PIXI_ENV' "${CONFIG_FILE}")"
     elif grep -q CONDA_ENV "${CONFIG_FILE}"; then  # backward compatibility
         echo "Determine pixi environment from CONDA_ENV entry in \"${CONFIG_FILE}\""
-        CONDA_ENVIRON="$(/bin/jq --raw-output '.CONDA_ENV' "${CONFIG_FILE}")"
-        if [[ "${CONDA_ENVIRON}" == *-dev ]]; then  # substitute dash for underscore in dev/qa suffix
-            PIXI_ENVIRON="${CONDA_ENVIRON%-dev}_dev"
-        elif [[ "${CONDA_ENVIRON}" == *-qa ]]; then
-            PIXI_ENVIRON="${CONDA_ENVIRON%-qa}_qa"
-        else
-            PIXI_ENVIRON="${CONDA_ENVIRON}"
+        PIXI_ENVIRON="$(/bin/jq --raw-output '.CONDA_ENV' "${CONFIG_FILE}")"
+        if [[ "${PIXI_ENVIRON}" == *-dev ]]; then  # substitute dash for underscore in dev/qa suffix
+            PIXI_ENVIRON="${PIXI_ENVIRON%-dev}_dev"
+        elif [[ "${PIXI_ENVIRON}" == *-qa ]]; then
+            PIXI_ENVIRON="${PIXI_ENVIRON%-qa}_qa"
         fi
     fi
 fi

--- a/scripts/livereduce.sh
+++ b/scripts/livereduce.sh
@@ -38,6 +38,9 @@ if [ -z "${NSD_APP_WRAP}" ];then
     exit 1
 fi
 
-# launch livereduce.py
+# Tell shellcheck where to find the sourced script for static analysis
+# shellcheck source=./nsd-app-wrap.sh
+# Disable SC1091 (file not found) since the path is resolved at runtime
+# shellcheck disable=SC1091
 . "${NSD_APP_WRAP}"  # load bash function `pixi_launch`
 pixi_launch "${PIXI_ENVIRON}" python "${APPLICATION}" "$@"

--- a/test/test_livereduce.bats
+++ b/test/test_livereduce.bats
@@ -1,0 +1,297 @@
+#!/usr/bin/env bats
+
+# test_livereduce.bats - Unit tests for livereduce.sh
+
+setup() {
+    # Create temporary directory for tests
+    export TEST_DIR="$(mktemp -d)"
+    export HOME="${TEST_DIR}"
+    export SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
+    export LIVEREDUCE_SCRIPT="${SCRIPT_DIR}/scripts/livereduce.sh"
+
+    # Create mock directories
+    mkdir -p "${TEST_DIR}/.cache/fontconfig"
+    mkdir -p "${TEST_DIR}/bin"
+
+    # Create mock files
+    touch "${TEST_DIR}/.cache/fontconfig/test.cache"
+}
+
+teardown() {
+    # Cleanup
+    if [ -n "${TEST_DIR}" ] && [ -d "${TEST_DIR}" ]; then
+        rm -rf "${TEST_DIR}"
+    fi
+}
+
+# Helper function to create test config files
+create_config_with_pixi_env() {
+    local config_file="$1"
+    local env_name="$2"
+    echo "{\"PIXI_ENV\": \"${env_name}\"}" > "${config_file}"
+}
+
+create_config_with_conda_env() {
+    local config_file="$1"
+    local env_name="$2"
+    echo "{\"CONDA_ENV\": \"${env_name}\"}" > "${config_file}"
+}
+
+# Test: Environment name conversion logic (isolated)
+@test "CONDA_ENV with -dev suffix converts to _dev" {
+    CONDA_ENVIRON="mantid-dev"
+    if [[ "${CONDA_ENVIRON}" == *-dev ]]; then
+        PIXI_ENVIRON="${CONDA_ENVIRON%-dev}_dev"
+    fi
+    [ "${PIXI_ENVIRON}" = "mantid_dev" ]
+}
+
+@test "CONDA_ENV with -qa suffix converts to _qa" {
+    CONDA_ENVIRON="mantid-qa"
+    if [[ "${CONDA_ENVIRON}" == *-qa ]]; then
+        PIXI_ENVIRON="${CONDA_ENVIRON%-qa}_qa"
+    fi
+    [ "${PIXI_ENVIRON}" = "mantid_qa" ]
+}
+
+@test "CONDA_ENV without suffix remains unchanged" {
+    CONDA_ENVIRON="mantid_prod"
+    PIXI_ENVIRON="${CONDA_ENVIRON}"
+    if [[ "${CONDA_ENVIRON}" == *-dev ]]; then
+        PIXI_ENVIRON="${CONDA_ENVIRON%-dev}_dev"
+    elif [[ "${CONDA_ENVIRON}" == *-qa ]]; then
+        PIXI_ENVIRON="${CONDA_ENVIRON%-qa}_qa"
+    fi
+    [ "${PIXI_ENVIRON}" = "mantid_prod" ]
+}
+
+@test "CONDA_ENV with -dev in middle doesn't convert" {
+    CONDA_ENVIRON="my-dev-environment"
+    PIXI_ENVIRON="${CONDA_ENVIRON}"
+    if [[ "${CONDA_ENVIRON}" == *-dev ]]; then
+        PIXI_ENVIRON="${CONDA_ENVIRON%-dev}_dev"
+    fi
+    [ "${PIXI_ENVIRON}" = "my-dev-environment" ]
+}
+
+@test "CONDA_ENV with -qa in middle doesn't convert" {
+    CONDA_ENVIRON="my-qa-test"
+    PIXI_ENVIRON="${CONDA_ENVIRON}"
+    if [[ "${CONDA_ENVIRON}" == *-qa ]]; then
+        PIXI_ENVIRON="${CONDA_ENVIRON%-qa}_qa"
+    fi
+    [ "${PIXI_ENVIRON}" = "my-qa-test" ]
+}
+
+# Test: Config file detection with mock script
+@test "uses default config path when no argument provided" {
+    # Test just the logic
+    run bash -c 'if [ $# -ge 1 ]; then echo "${1}"; else echo "/etc/livereduce.conf"; fi'
+    [ "$status" -eq 0 ]
+    [ "$output" = "/etc/livereduce.conf" ]
+}
+
+@test "uses provided config file path" {
+    run bash -c 'if [ $# -ge 1 ]; then echo "${1}"; else echo "/etc/livereduce.conf"; fi' -- "/custom/path.conf"
+    [ "$status" -eq 0 ]
+    [ "$output" = "/custom/path.conf" ]
+}
+
+# Test: JSON parsing with jq
+@test "jq correctly parses PIXI_ENV from config" {
+    local config="${TEST_DIR}/test.conf"
+    create_config_with_pixi_env "${config}" "test_env"
+
+    result=$(/bin/jq --raw-output '.PIXI_ENV' "${config}")
+    [ "$result" = "test_env" ]
+}
+
+@test "jq correctly parses CONDA_ENV from config" {
+    local config="${TEST_DIR}/test.conf"
+    create_config_with_conda_env "${config}" "conda_env"
+
+    result=$(/bin/jq --raw-output '.CONDA_ENV' "${config}")
+    [ "$result" = "conda_env" ]
+}
+
+# Test: grep detection of keys in config
+@test "grep finds PIXI_ENV in config file" {
+    local config="${TEST_DIR}/test.conf"
+    create_config_with_pixi_env "${config}" "test_env"
+
+    run grep -q PIXI_ENV "${config}"
+    [ "$status" -eq 0 ]
+}
+
+@test "grep finds CONDA_ENV in config file" {
+    local config="${TEST_DIR}/test.conf"
+    create_config_with_conda_env "${config}" "test_env"
+
+    run grep -q CONDA_ENV "${config}"
+    [ "$status" -eq 0 ]
+}
+
+@test "grep doesn't find PIXI_ENV when not present" {
+    local config="${TEST_DIR}/test.conf"
+    create_config_with_conda_env "${config}" "test_env"
+
+    run grep -q PIXI_ENV "${config}"
+    [ "$status" -eq 1 ]
+}
+
+# Test: Font cache removal
+@test "font cache files are removed" {
+    touch "${HOME}/.cache/fontconfig/test1.cache"
+    touch "${HOME}/.cache/fontconfig/test2.cache"
+
+    rm -f "${HOME}"/.cache/fontconfig/*
+
+    run ls "${HOME}/.cache/fontconfig/"
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 0 ]
+}
+
+# Test: readlink resolves script path
+@test "readlink -f resolves script path" {
+    local test_script="${TEST_DIR}/test.sh"
+    echo "#!/bin/bash" > "${test_script}"
+    chmod +x "${test_script}"
+
+    result=$(readlink -f "${test_script}")
+    [[ "${result}" == "${TEST_DIR}/test.sh" ]]
+}
+
+# Test: dirname extracts directory
+@test "dirname extracts directory from path" {
+    result=$(dirname "/usr/bin/livereduce.sh")
+    [ "$result" = "/usr/bin" ]
+}
+
+# Test: Integration test with mock nsd-app-wrap.sh
+@test "script fails when nsd-app-wrap.sh is missing" {
+    local config="${TEST_DIR}/test.conf"
+    create_config_with_pixi_env "${config}" "test_env"
+
+    # Create a test version of the script that stops before calling pixi_launch
+    local test_script="${TEST_DIR}/livereduce_test.sh"
+    cat > "${test_script}" << 'EOF'
+#!/bin/bash
+THISFILE=$(readlink -f "$0")
+INSTALLDIR=$(dirname "${THISFILE}")
+NSD_APP_WRAP="${INSTALLDIR}/nsd-app-wrap.sh"
+if [ ! -f "${NSD_APP_WRAP}" ]; then
+    echo "Failed to find nsd-app-wrap.sh"
+    exit 1
+fi
+EOF
+    chmod +x "${test_script}"
+
+    run "${test_script}"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Failed to find nsd-app-wrap.sh" ]]
+}
+
+# Test: Complete environment resolution logic
+@test "PIXI_ENV takes precedence over CONDA_ENV" {
+    local config="${TEST_DIR}/test.conf"
+    echo '{"PIXI_ENV": "pixi_test", "CONDA_ENV": "conda_test"}' > "${config}"
+
+    # Simulate the script logic
+    PIXI_ENVIRON="mantid_dev"
+    if grep -q PIXI_ENV "${config}"; then
+        PIXI_ENVIRON="$(/bin/jq --raw-output '.PIXI_ENV' "${config}")"
+    elif grep -q CONDA_ENV "${config}"; then
+        CONDA_ENVIRON="$(/bin/jq --raw-output '.CONDA_ENV' "${config}")"
+        if [[ "${CONDA_ENVIRON}" == *-dev ]]; then
+            PIXI_ENVIRON="${CONDA_ENVIRON%-dev}_dev"
+        elif [[ "${CONDA_ENVIRON}" == *-qa ]]; then
+            PIXI_ENVIRON="${CONDA_ENVIRON%-qa}_qa"
+        fi
+    fi
+
+    [ "${PIXI_ENVIRON}" = "pixi_test" ]
+}
+
+@test "CONDA_ENV with -dev is converted when PIXI_ENV not present" {
+    local config="${TEST_DIR}/test.conf"
+    echo '{"CONDA_ENV": "mantid-dev"}' > "${config}"
+
+    # Simulate the script logic
+    PIXI_ENVIRON="mantid_dev"
+    if grep -q PIXI_ENV "${config}"; then
+        PIXI_ENVIRON="$(/bin/jq --raw-output '.PIXI_ENV' "${config}")"
+    elif grep -q CONDA_ENV "${config}"; then
+        CONDA_ENVIRON="$(/bin/jq --raw-output '.CONDA_ENV' "${config}")"
+        if [[ "${CONDA_ENVIRON}" == *-dev ]]; then
+            PIXI_ENVIRON="${CONDA_ENVIRON%-dev}_dev"
+        elif [[ "${CONDA_ENVIRON}" == *-qa ]]; then
+            PIXI_ENVIRON="${CONDA_ENVIRON%-qa}_qa"
+        fi
+    fi
+
+    [ "${PIXI_ENVIRON}" = "mantid_dev" ]
+}
+
+@test "CONDA_ENV with -qa is converted when PIXI_ENV not present" {
+    local config="${TEST_DIR}/test.conf"
+    echo '{"CONDA_ENV": "mantid-qa"}' > "${config}"
+
+    # Simulate the script logic
+    PIXI_ENVIRON="mantid_dev"
+    if grep -q PIXI_ENV "${config}"; then
+        PIXI_ENVIRON="$(/bin/jq --raw-output '.PIXI_ENV' "${config}")"
+    elif grep -q CONDA_ENV "${config}"; then
+        CONDA_ENVIRON="$(/bin/jq --raw-output '.CONDA_ENV' "${config}")"
+        if [[ "${CONDA_ENVIRON}" == *-dev ]]; then
+            PIXI_ENVIRON="${CONDA_ENVIRON%-dev}_dev"
+        elif [[ "${CONDA_ENVIRON}" == *-qa ]]; then
+            PIXI_ENVIRON="${CONDA_ENVIRON%-qa}_qa"
+        fi
+    fi
+
+    [ "${PIXI_ENVIRON}" = "mantid_qa" ]
+}
+
+@test "default PIXI_ENVIRON used when config file doesn't exist" {
+    local config="${TEST_DIR}/nonexistent.conf"
+
+    # Simulate the script logic
+    PIXI_ENVIRON="mantid_dev"
+    if [ -f "${config}" ]; then
+        if grep -q PIXI_ENV "${config}"; then
+            PIXI_ENVIRON="$(/bin/jq --raw-output '.PIXI_ENV' "${config}")"
+        fi
+    fi
+
+    [ "${PIXI_ENVIRON}" = "mantid_dev" ]
+}
+
+# Test: Argument passing
+@test "script arguments are printed" {
+    run bash -c 'echo "ARGS $*"' -- arg1 arg2 arg3
+    [ "$status" -eq 0 ]
+    [ "$output" = "ARGS arg1 arg2 arg3" ]
+}
+
+# Test: Using actual fake.conf from test directory
+@test "can parse CONDA_ENV from test/fake.conf" {
+    local config="${SCRIPT_DIR}/test/fake.conf"
+
+    if [ -f "${config}" ]; then
+        result=$(/bin/jq --raw-output '.CONDA_ENV' "${config}")
+        [ "$result" = "livereduce" ]
+    else
+        skip "test/fake.conf not found"
+    fi
+}
+
+# Test: Variable assignment check
+@test "empty variable check works as expected" {
+    NSD_APP_WRAP=""
+    run bash -c '[ -z "${NSD_APP_WRAP}" ] && echo "empty" || echo "not empty"'
+    [ "$output" = "empty" ]
+
+    NSD_APP_WRAP="/some/path"
+    run bash -c 'NSD_APP_WRAP="/some/path"; [ -z "${NSD_APP_WRAP}" ] && echo "empty" || echo "not empty"'
+    [ "$output" = "not empty" ]
+}

--- a/test/test_livereduce.bats
+++ b/test/test_livereduce.bats
@@ -4,9 +4,13 @@
 
 setup() {
     # Create temporary directory for tests
-    export TEST_DIR="$(mktemp -d)"
+    local temp_dir
+    temp_dir="$(mktemp -d)"
+    export TEST_DIR="${temp_dir}"
     export HOME="${TEST_DIR}"
-    export SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
+    local script_dir
+    script_dir="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
+    export SCRIPT_DIR="${script_dir}"
     export LIVEREDUCE_SCRIPT="${SCRIPT_DIR}/scripts/livereduce.sh"
 
     # Create mock directories
@@ -188,7 +192,7 @@ EOF
 
     run "${test_script}"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Failed to find nsd-app-wrap.sh" ]]
+    [[ "$output" =~ Failed\ to\ find\ nsd-app-wrap.sh ]]
 }
 
 # Test: Complete environment resolution logic
@@ -287,11 +291,10 @@ EOF
 
 # Test: Variable assignment check
 @test "empty variable check works as expected" {
-    NSD_APP_WRAP=""
+    export NSD_APP_WRAP=""
     run bash -c '[ -z "${NSD_APP_WRAP}" ] && echo "empty" || echo "not empty"'
     [ "$output" = "empty" ]
 
-    NSD_APP_WRAP="/some/path"
     run bash -c 'NSD_APP_WRAP="/some/path"; [ -z "${NSD_APP_WRAP}" ] && echo "empty" || echo "not empty"'
     [ "$output" = "not empty" ]
 }


### PR DESCRIPTION
This PR migrates from conda to pixi, adding unit tests for livereduce.sh, and updating documentation accordingly.  
EWM [14930](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14930)

**Changes:**

Migrated from CONDA_ENV to PIXI_ENV with backward compatibility support for legacy configurations
Added  BATS unit tests to validate the bash script logic of livereduce.sh
Updated documentation to reflect the pixi environment naming conventions