### PR TITLE
Inject version number into rpmbuild

### DIFF
--- a/livereduce.spec
+++ b/livereduce.spec
@@ -5,7 +5,7 @@
 
 Summary: %{summary}
 Name: python-%{srcname}
-Version: 1.18
+Version: %{version}
 Release: %{release}%{?dist}
 Source0: %{srcname}-%{version}.tar.gz
 License: MIT

--- a/livereduce.spec
+++ b/livereduce.spec
@@ -2,6 +2,10 @@
 %global summary Daemon for running live data reduction with systemd
 # This only supports python3
 %define release 1
+# give default version for linting
+%if "%{?version}" == ""
+%define version 0.0
+%endif
 
 Summary: %{summary}
 Name: python-%{srcname}

--- a/pixi.lock
+++ b/pixi.lock
@@ -1431,9 +1431,10 @@ packages:
   timestamp: 1727963148474
 - pypi: ./
   name: livereduce
-  version: '1.18'
-  sha256: 8ab93ae10897a370bcd46d1aba26b3cbf70e578fe67737d0055261f068bd5420
+  version: '1.19'
+  sha256: 359b897d10616e6e9d2e72da299ca6d6a4e6b08f62a3880b39651efccb8c1201
   requires_python: '>=3.9'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
   sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346
   md5: 9de5350a85c4a20c685259b889aa6393

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "livereduce"
 description = "Daemon for running live data reduction with systemd"
-version="1.18"
+version= "1.19"
 requires-python = ">=3.9"
 license = { text = "MIT License" }
 authors = [{name="Pete Peterson",email="petersonpf@ornl.gov"}]

--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -6,7 +6,7 @@
 SPECFILE="$(dirname "$(realpath "$0")")/livereduce.spec"
 
 # Get the version from the pyproject.toml file
-VERSION=$(pixi workspace version get)
+VERSION=$(grep ^version pyproject.toml | cut -d "=" -f 2 | sed 's/"//g' | tr -d ' ')
 echo "version in pyproject.toml is ${VERSION}"
 
 # Create the source tarball

--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -6,7 +6,7 @@
 SPECFILE="$(dirname "$(realpath "$0")")/livereduce.spec"
 
 # Get the version from the pyproject.toml file
-VERSION=$(grep ^version pyproject.toml | cut -d "=" -f 2 | sed 's/"//g' | tr -d ' ')
+VERSION=$(pixi workspace version get)
 echo "version in pyproject.toml is ${VERSION}"
 
 # Create the source tarball


### PR DESCRIPTION
This changes the rpm to inject the version number that is set in the `pyproject.toml`. I also bumped the version number using
```sh
pixi workspace version minor
```

## Warnings
* There is a default version set in the `livereduce.spec` file because rpmlint doesn't allow injecting information such as version number
* pixi isn't installed inside the docker image so `pixi workspace version` fails

## To test
```sh
./rpmbuild.sh
```
and see that the version number on the rpm is 1.19