### PR TITLE
Wait for asynchronous algorithms to finish

### DIFF
--- a/livereduce.service
+++ b/livereduce.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Live processing service
-StartLimitInterval=8640
+StartLimitIntervalSec=8640
 StartLimitBurst=1000
 
 [Service]

--- a/livereduce_watchdog.service
+++ b/livereduce_watchdog.service
@@ -4,7 +4,6 @@ After=livereduce.service
 
 [Service]
 WorkingDirectory=/tmp
-User=snsdata
 ExecStart=/usr/bin/livereduce_watchdog.sh
 Restart=always
 RestartSec=10

--- a/livereduce_watchdog.service
+++ b/livereduce_watchdog.service
@@ -4,7 +4,7 @@ After=livereduce.service
 
 [Service]
 WorkingDirectory=/tmp
-User=root
+User=snsdata
 ExecStart=/usr/bin/livereduce_watchdog.sh
 Restart=always
 RestartSec=10

--- a/livereduce_watchdog.service
+++ b/livereduce_watchdog.service
@@ -4,6 +4,7 @@ After=livereduce.service
 
 [Service]
 WorkingDirectory=/tmp
+User=root
 ExecStart=/usr/bin/livereduce_watchdog.sh
 Restart=always
 RestartSec=10

--- a/pixi.lock
+++ b/pixi.lock
@@ -7,8 +7,6 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -1431,8 +1429,8 @@ packages:
   timestamp: 1727963148474
 - pypi: ./
   name: livereduce
-  version: '1.19'
-  sha256: 359b897d10616e6e9d2e72da299ca6d6a4e6b08f62a3880b39651efccb8c1201
+  version: '1.20'
+  sha256: d48559c0f7187c479bd5838a005becac8384476428cb3128630b70cd3f665323
   requires_python: '>=3.9'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "livereduce"
 description = "Daemon for running live data reduction with systemd"
-version= "1.19"
+version= "1.20"
 requires-python = ">=3.9"
 license = { text = "MIT License" }
 authors = [{name="Pete Peterson",email="petersonpf@ornl.gov"}]

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -109,7 +109,10 @@ def sigterm_handler(sig_received, frame):  # noqa: ARG001
     msg = f"received {sig_name[sig_received]}({sig_received})"
     # logger.debug( "SIGTERM received")
     logger.info(msg)
-    LiveDataManager.stop()
+    try:
+        LiveDataManager.stop()  # may raise if algorithm MonitorLiveData does not finish
+    except RuntimeError as ex:
+        logger.error(ex)
     if sig_received == signal.SIGINT:
         raise KeyboardInterrupt(msg)
     elif sig_received == signal.SIGTERM:

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -288,6 +288,7 @@ class Config:
             UpdateEvery=self.updateEvery,
             PreserveEvents=self.preserveEvents,
             AccumulationMethod=self.accumMethod,
+            AccumulationWorkspace=mtd.unique_hidden_name(prefix="input_"),
             OutputWorkspace="result",
         )
 

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -82,7 +82,9 @@ class LiveDataManager:
         """Determine if mantid is running and shuts it down"""
         if "mantid" in locals() or "mantid" in globals():
             cls.logger.info("stopping live data processing")
-            mantid.AlgorithmManager.cancelAll()
+            mantid.AlgorithmManager.shutdown()  # wait until all asynchronous-started algorithms complete
+            if mantid.AlgorithmManager.runningInstancesOf("MonitorLiveData"):
+                raise RuntimeError("MonitorLiveData algorithm could not be stopped")
         else:
             cls.logger.info("mantid not initialized - nothing to cleanup")
 

--- a/scripts/livereduce.py
+++ b/scripts/livereduce.py
@@ -290,7 +290,6 @@ class Config:
             UpdateEvery=self.updateEvery,
             PreserveEvents=self.preserveEvents,
             AccumulationMethod=self.accumMethod,
-            AccumulationWorkspace=mtd.unique_hidden_name(prefix="input_"),
             OutputWorkspace="result",
         )
 
@@ -304,7 +303,7 @@ class Config:
 
         if self.postProcScriptExist:
             self.logger.info(f"Using PostProcessingScriptFilename '{self.postProcScript}'")
-            args["AccumulationWorkspace"] = "accumulation"
+            args["AccumulationWorkspace"] = mtd.unique_hidden_name(prefix="accumulation_")
             args["PostProcessingScriptFilename"] = self.postProcScript
 
         if self.periods is not None:


### PR DESCRIPTION
### Description of Changes 
Changing how live algorithms are stopped and by explicitly setting an accumulation workspace name when starting live reduction.

- Replace AlgorithmManager.cancelAll() with AlgorithmManager.shutdown() and add a check that MonitorLiveData is no longer running.
- Provide an explicit (unique) AccumulationWorkspace name in StartLiveData arguments.
- Run the watchdog service as `root` so that the service has permissions to restart service `livereduce`.