### PR TITLE
Add polkit rule for watchdog to do its thing

### DIFF
--- a/50-snsdata-livereduce.rules
+++ b/50-snsdata-livereduce.rules
@@ -1,0 +1,9 @@
+polkit.addRule(function(action, subject) {
+    var verb = action.lookup("verb");
+    if (action.id == "org.freedesktop.systemd1.manage-units" &&
+        subject.user == "snsdata" &&
+        action.lookup("unit") == "livereduce.service" &&
+        (verb == "start" || verb == "stop" || verb == "restart")) {
+        return polkit.Result.YES;
+    }
+});

--- a/livereduce.spec
+++ b/livereduce.spec
@@ -26,6 +26,7 @@ BuildRequires: systemd-rpm-macros
 Requires: python%{python3_pkgversion}
 Requires: jq
 Requires: nsd-app-wrap
+Requires: polkit
 Requires: systemd
 
 %description
@@ -103,4 +104,4 @@ Daemon that monitors the livereduce log file and restarts service livereduce if 
 %files watchdog
 %{_bindir}/livereduce_watchdog.sh
 %{_unitdir}/livereduce_watchdog.service
-%{_sysconfdir}/polkit-1/rules.d/50-snsdata-livereduce.rules
+%config(noreplace) %{_sysconfdir}/polkit-1/rules.d/50-snsdata-livereduce.rules

--- a/livereduce.spec
+++ b/livereduce.spec
@@ -58,6 +58,8 @@ Daemon that monitors the livereduce log file and restarts service livereduce if 
 # watchdog service
 %{__install} -m 755 scripts/livereduce_watchdog.sh %{buildroot}%{_bindir}/
 %{__install} -m 644 livereduce_watchdog.service %{buildroot}%{_unitdir}/
+%{__mkdir} -p %{buildroot}%{_sysconfdir}/polkit-1/rules.d/
+%{__install} -m 644 50-snsdata-livereduce.rules %{buildroot}%{_sysconfdir}/polkit-1/rules.d/
 
 %check
 # no test step
@@ -101,3 +103,4 @@ Daemon that monitors the livereduce log file and restarts service livereduce if 
 %files watchdog
 %{_bindir}/livereduce_watchdog.sh
 %{_unitdir}/livereduce_watchdog.service
+%{_sysconfdir}/polkit-1/rules.d/50-snsdata-livereduce.rules

--- a/pixi.lock
+++ b/pixi.lock
@@ -1425,10 +1425,9 @@ packages:
   timestamp: 1774072609062
 - pypi: ./
   name: livereduce
-  version: '1.21'
-  sha256: b6c2e53a8d551242fe901a7201f33aee1410f22c767b4ea8241652df0478e2f6
+  version: '1.22'
+  sha256: d3321020489459e10928824ccbebcf38ba9c4e4cf77b9d4d3dbff6d20ebe87b2
   requires_python: '>=3.9'
-  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
   sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346
   md5: 9de5350a85c4a20c685259b889aa6393

--- a/pixi.lock
+++ b/pixi.lock
@@ -1426,7 +1426,7 @@ packages:
 - pypi: ./
   name: livereduce
   version: '1.22'
-  sha256: d3321020489459e10928824ccbebcf38ba9c4e4cf77b9d4d3dbff6d20ebe87b2
+  sha256: e45bf0c4131158a314b78ced1c29215b9602690c45d14215d2eff51799519cff
   requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
   sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "livereduce"
 description = "Daemon for running live data reduction with systemd"
-version= "1.21"
+version= "1.22"
 requires-python = ">=3.9"
 license = { text = "MIT License" }
 authors = [{name="Pete Peterson",email="petersonpf@ornl.gov"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "livereduce"
 description = "Daemon for running live data reduction with systemd"
-version= "1.22"
+version = "1.22"
 requires-python = ">=3.9"
 license = { text = "MIT License" }
 authors = [{name="Pete Peterson",email="petersonpf@ornl.gov"}]


### PR DESCRIPTION
This adds rules to polkit so `livereduce-watchdog` can restart `livereduce`, assuming watchdog is running as the correct user. The docs I read suggested that polkit will automatically reload the rules, which appears to be the case via
```sh
$ sudo journalctl -u polkit
...
Apr 09 14:07:08 ndav.sns.gov polkitd[1965]: Reloading rules
Apr 09 14:07:08 ndav.sns.gov polkitd[1965]: Collecting garbage unconditionally...
Apr 09 14:07:08 ndav.sns.gov polkitd[1965]: Loading rules from directory /etc/polkit-1/rules.d
Apr 09 14:07:08 ndav.sns.gov polkitd[1965]: Loading rules from directory /usr/share/polkit-1/rules.d
Apr 09 14:07:08 ndav.sns.gov polkitd[1965]: Finished loading, compiling and executing 13 rules
Apr 09 14:07:08 ndav.sns.gov polkitd[1965]: Reloading rules
Apr 09 14:07:08 ndav.sns.gov polkitd[1965]: Collecting garbage unconditionally...
Apr 09 14:07:08 ndav.sns.gov polkitd[1965]: Loading rules from directory /etc/polkit-1/rules.d
Apr 09 14:07:08 ndav.sns.gov polkitd[1965]: Loading rules from directory /usr/share/polkit-1/rules.d
Apr 09 14:07:08 ndav.sns.gov polkitd[1965]: Finished loading, compiling and executing 13 rules
```

References:
* [random polkit guide](https://oneuptime.com/blog/post/2026-03-02-how-to-set-up-polkit-rules-for-privilege-escalation-on-ubuntu/view)
* [list of rpm macros](https://docs.fedoraproject.org/en-US/packaging-guidelines/RPMMacros/)
* [systemd scriptlets](https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_systemd)